### PR TITLE
Always use `rsync` to copy static content during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,13 @@
   "scripts": {
     "dev": "next dev",
     "dev:content": "next-remote-watch content",
-    "build": "npm run create-indexes && npm run copy-static-content:cp && npm run build:next",
+    "build": "npm run create-indexes && npm run copy-static-content && npm run build:next",
     "build:next": "next build",
     "start": "next start",
     "lint": "next lint",
     "check-types": "tsc --noEmit",
     "create-indexes": "esno ./content-processing/create-indexes.ts",
-    "copy-static-content:rsync": "rsync -avh --exclude='**/*.mdx' content/articles/ public/static-content/",
-    "copy-static-content:cp": "cp -r content/articles/. public/static-content/"
+    "copy-static-content": "rsync -avh --exclude='**/*.mdx' content/articles/ public/static-content/"
   },
   "dependencies": {
     "@emotion/react": "^11.9.0",


### PR DESCRIPTION
Use `rsync` on Vercel instead of doing a simple `cp`.

This requires installing `rsync` on Vercel in [the build command](https://vercel.com/docs/concepts/deployments/build-step#build-image):

```sh
yum install rsync.x86_64 -y && npm run build
```