### PR TITLE
refactor(ui): revamp article styling

### DIFF
--- a/components/AboutPage/AboutPage.tsx
+++ b/components/AboutPage/AboutPage.tsx
@@ -7,12 +7,10 @@ import {
 } from "../../styles/layout";
 import { containerWidth, rem, spacing } from "../../styles/theme";
 import { headingStyle } from "../../styles/typography";
-import {
-  StyledArticleParagraph,
-  StyledArticleParagraphLink,
-} from "../ArticlePage/styled-components";
 import { Layout } from "../Layout";
 import { HeadDocumentTitle, HeadMetaDescription } from "../../seo";
+import { Paragraph, ParagraphLink } from "../text";
+import meImage from "../../public/images/me.jpg";
 
 export const AboutPage = () => {
   return (
@@ -30,20 +28,21 @@ export const AboutPage = () => {
             My name is Grzegorz Rozdzialik (pronounced “Rossgialik”), but I go
             by <StyledAccent>Greg</StyledAccent>. I am a Senior Software
             Engineer working at{" "}
-            <StyledArticleParagraphLink href="https://www.splitgraph.com/">
+            <ParagraphLink href="https://www.splitgraph.com/">
               Splitgraph
-            </StyledArticleParagraphLink>
+            </ParagraphLink>
             .
           </StyledAboutParagraph>
         </StyledAlwaysLeftColumn>
 
         <StyledHeroImageContainer>
           <StyledHeroImage
-            src="/images/me.jpg"
+            src={meImage}
             alt="A picture of me in Vienna"
             width={4000}
             height={2250}
             layout="responsive"
+            placeholder="blur"
           />
         </StyledHeroImageContainer>
 
@@ -60,9 +59,9 @@ export const AboutPage = () => {
 
           <StyledAboutParagraph>
             You can find more of my work on{" "}
-            <StyledArticleParagraphLink href="https://github.com/Gelio">
+            <ParagraphLink href="https://github.com/Gelio">
               my GitHub profile
-            </StyledArticleParagraphLink>
+            </ParagraphLink>
             .
           </StyledAboutParagraph>
         </StyledAlwaysLeftColumn>
@@ -102,7 +101,7 @@ const StyledAccent = styled("span")(({ theme }) => ({
   color: theme.color.primary.main,
 }));
 
-const StyledAboutParagraph = styled(StyledArticleParagraph)({
+const StyledAboutParagraph = styled(Paragraph)({
   marginBlockEnd: rem(spacing(1)),
 });
 

--- a/components/ArticleCard/ArticleCard.tsx
+++ b/components/ArticleCard/ArticleCard.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import Link from "next/link";
-import { ComponentProps, ElementType, ReactNode } from "react";
+import type { ComponentProps, ElementType, ReactNode } from "react";
 
 import { rem, spacing } from "../../styles/theme";
 import { articleTitleStyle } from "../../styles/typography";

--- a/components/ArticleCard/IndexedArticleCard.tsx
+++ b/components/ArticleCard/IndexedArticleCard.tsx
@@ -4,8 +4,9 @@ import { task } from "fp-ts";
 import { pipe } from "fp-ts/function";
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
 import { serialize } from "next-mdx-remote/serialize";
-import { IndexedArticleMetadata } from "../../content-processing/indexes/schema";
-import { StyledArticleParagraph } from "../ArticlePage/styled-components";
+import type { IndexedArticleMetadata } from "../../content-processing/indexes/schema";
+import { baseMDXComponents } from "../mdx";
+import { Paragraph } from "../text";
 import { ArticleCard } from "./ArticleCard";
 
 export type IndexedArticleMetadataWithSerializedSummary = Omit<
@@ -29,6 +30,7 @@ export const IndexedArticleCard = ({ metadata }: IndexedArticleCardProps) => (
     summary={
       <MDXProvider
         components={{
+          ...baseMDXComponents,
           p: StyledArticleCardSummary,
         }}
       >
@@ -38,7 +40,7 @@ export const IndexedArticleCard = ({ metadata }: IndexedArticleCardProps) => (
   />
 );
 
-const StyledArticleCardSummary = styled(StyledArticleParagraph)({
+const StyledArticleCardSummary = styled(Paragraph)({
   margin: 0,
 });
 

--- a/components/ArticlePage/ArticleHeader.tsx
+++ b/components/ArticlePage/ArticleHeader.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { ComponentProps } from "react";
+import type { ComponentProps } from "react";
 
 import {
   responsiveContainer,

--- a/components/ArticlePage/styled-components.tsx
+++ b/components/ArticlePage/styled-components.tsx
@@ -4,27 +4,10 @@ import {
   responsiveContainer,
   responsiveContainerInlinePadding,
 } from "../../styles/layout";
-import { rem, spacing } from "../../styles/theme";
-import { headingStyle } from "../../styles/typography";
 
 export const StyledArticleSection = styled("section")(
   responsiveContainer,
   responsiveContainerInlinePadding
 );
-
-export const StyledArticleParagraph = styled("p")({
-  lineHeight: 1.5,
-  marginBlockStart: 0,
-});
-
-export const StyledArticleSectionHeading = styled("h2")(headingStyle, {
-  marginBlockStart: rem(spacing(4)),
-  marginBlockEnd: rem(spacing(1)),
-});
-
-export const StyledArticleParagraphLink = styled("a")(({ theme }) => ({
-  textDecoration: "underline",
-  color: theme.color.primary.main,
-}));
 
 export const StyledArticleContainer = styled("article")(pageContentMarginTop);

--- a/components/HomePage/HomePage.tsx
+++ b/components/HomePage/HomePage.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { either } from "fp-ts";
 import { pipe } from "fp-ts/function";
-import { ReadAllArticlesIndexError } from "../../content-processing/indexes";
+import type { ReadAllArticlesIndexError } from "../../content-processing/indexes";
 import { HeadDocumentTitle, HeadMetaDescription } from "../../seo";
 
 import {
@@ -20,6 +20,7 @@ import {
   ErrorAlertContainer,
 } from "../ErrorAlert";
 import { Layout } from "../Layout";
+import { Paragraph } from "../text";
 
 interface HomePageProps {
   allArticlesResult: either.Either<
@@ -37,7 +38,7 @@ export const HomePage = ({ allArticlesResult }: HomePageProps) => {
       </HeadMetaDescription>
 
       <StyledMainContent>
-        Hey, I&apos;m Greg, welcome to my blog!
+        <Paragraph>Hey, I&apos;m Greg, welcome to my blog!</Paragraph>
       </StyledMainContent>
 
       {pipe(

--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -16,9 +16,9 @@ const StyledFooterText = styled("footer")(
   responsiveContainerInlinePadding,
   ({ theme }) => ({
     color: theme.color.text.desaturated,
-    fontSize: rem(12),
-    paddingBlockEnd: rem(spacing(1)),
-    height: rem(spacing(4)),
+    fontSize: rem(14),
+    paddingBlockEnd: rem(spacing(2)),
+    height: rem(spacing(5)),
 
     display: "flex",
     alignItems: "end",

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import type { PropsWithChildren } from "react";
+import { rem, spacing } from "../../styles/theme";
 import { Footer } from "./Footer";
 import { Header } from "./Header";
 
@@ -21,4 +22,5 @@ const LayoutContainer = styled("div")({
 // shorter than 100vh
 const MainContainer = styled("main")({
   flexGrow: 1,
+  marginBlockEnd: rem(spacing(20)),
 });

--- a/components/TopicPage/TopicPage.tsx
+++ b/components/TopicPage/TopicPage.tsx
@@ -21,6 +21,7 @@ import {
 } from "../ErrorAlert";
 import { HeadDocumentTitle, HeadMetaDescription } from "../../seo";
 import { Layout } from "../Layout";
+import { Paragraph } from "../text";
 
 interface TopicPageProps {
   topicName: string;
@@ -41,7 +42,7 @@ export const TopicPage = ({ topicName, articlesResult }: TopicPageProps) => {
       <StyledMainContent>
         <StyledPageTitle>Articles about {topicName}</StyledPageTitle>
 
-        <StyledTopicDescription>
+        <Paragraph>
           {pipe(
             articlesResult,
             either.match(
@@ -50,7 +51,7 @@ export const TopicPage = ({ topicName, articlesResult }: TopicPageProps) => {
               ({ description }) => description
             )
           )}
-        </StyledTopicDescription>
+        </Paragraph>
       </StyledMainContent>
 
       {pipe(
@@ -105,12 +106,8 @@ const StyledMainContent = styled("main")(
 );
 
 const StyledPageTitle = styled("h1")(headingStyle, {
-  marginBlock: 0,
-});
-
-const StyledTopicDescription = styled("p")({
-  marginBlockStart: rem(spacing(1)),
-  marginBlockEnd: rem(spacing(2)),
+  marginBlockStart: spacing(3),
+  marginBlockEnd: spacing(2),
 });
 
 const StyledArticleCardsContainer = styled("div")(

--- a/components/TopicsPage/TopicsPage.tsx
+++ b/components/TopicsPage/TopicsPage.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { either } from "fp-ts";
 import { pipe } from "fp-ts/function";
 import Link from "next/link";
-import { readTopicsSummaryIndex } from "../../content-processing/indexes/per-topic";
+import type { readTopicsSummaryIndex } from "../../content-processing/indexes/per-topic";
 import {
   pageContentMarginTop,
   responsiveContainer,
@@ -84,4 +84,5 @@ const TopicsContainer = styled("main")(
 
 const TopicLink = styled("a")(decorationOnHoverLinkStyle, ({ theme }) => ({
   color: theme.color.primary.main,
+  fontSize: rem(18),
 }));

--- a/components/mdx/components.tsx
+++ b/components/mdx/components.tsx
@@ -1,0 +1,90 @@
+import styled from "@emotion/styled";
+import type { Components as MDXComponents } from "@mdx-js/react/lib";
+import Image from "next/image";
+import Link from "next/link";
+import { createContext, useContext } from "react";
+import { rem, spacing } from "../../styles/theme";
+import {
+  ArticleHeading2,
+  ArticleHeading3,
+  Paragraph,
+  ParagraphLink,
+} from "../text";
+
+export const MDXLink: MDXComponents["a"] = (props) =>
+  props.href ? (
+    <Link href={props.href} passHref>
+      <ParagraphLink {...props} />
+    </Link>
+  ) : (
+    (() => {
+      throw new Error("Link does not have a href");
+    })()
+  );
+
+export const MDXImage: MDXComponents["img"] = (props) => (
+  <Image
+    // NOTE: required to fix a TS error
+    src={props.src as string}
+    // NOTE: required to tell ESLint we do pass `alt`
+    alt={props.alt}
+    {...props}
+    layout="responsive"
+    // TODO: implement blur placeholders for all photos
+    placeholder="empty"
+  />
+);
+
+export const BlockQuote = styled("blockquote")(({ theme }) => ({
+  borderInlineStart: "solid 3px",
+  borderColor: theme.color.primary.main,
+
+  marginInlineStart: rem(spacing(1)),
+  paddingInlineStart: rem(spacing(2)),
+}));
+
+const InsideCodeBlockContext = createContext(false);
+
+export const Pre: MDXComponents["pre"] = (props) => {
+  return (
+    <InsideCodeBlockContext.Provider value={true}>
+      <pre {...props} />
+    </InsideCodeBlockContext.Provider>
+  );
+};
+
+export const StyledInlineCode = styled("code")(({ theme }) => ({
+  backgroundColor: theme.color.text.main,
+  color: theme.color.primary.light,
+  borderRadius: spacing(1),
+  paddingBlock: spacing(0.25),
+  paddingInline: spacing(0.5),
+  wordBreak: "break-word",
+}));
+
+export const InlineCode: MDXComponents["code"] = (props) => {
+  const insideCodeBlock = useContext(InsideCodeBlockContext);
+
+  if (insideCodeBlock) {
+    return <code {...props} />;
+  } else {
+    return <StyledInlineCode {...props} />;
+  }
+};
+
+export const ListItem = styled("li")({
+  marginBlockEnd: spacing(2),
+  fontSize: rem(18),
+});
+
+export const baseMDXComponents = {
+  a: MDXLink,
+  p: Paragraph,
+  img: MDXImage,
+  h2: ArticleHeading2,
+  h3: ArticleHeading3,
+  blockquote: BlockQuote,
+  code: InlineCode,
+  pre: Pre,
+  li: ListItem,
+};

--- a/components/mdx/index.ts
+++ b/components/mdx/index.ts
@@ -1,0 +1,1 @@
+export * from "./components";

--- a/components/text/Paragraph.tsx
+++ b/components/text/Paragraph.tsx
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+import { rem, spacing } from "../../styles/theme";
+
+export const Paragraph = styled("p")({
+  lineHeight: 1.5,
+  marginBlockStart: 0,
+  marginBlockEnd: rem(spacing(3)),
+  fontSize: rem(18),
+});
+
+export const ParagraphLink = styled("a")(({ theme }) => ({
+  textDecoration: "underline",
+  color: theme.color.primary.main,
+}));

--- a/components/text/headings.tsx
+++ b/components/text/headings.tsx
@@ -1,0 +1,16 @@
+import styled from "@emotion/styled";
+import { rem } from "../../styles/theme";
+
+export const ArticleHeading2 = styled("h2")({
+  fontWeight: "normal",
+  fontSize: rem(30),
+  marginBlockStart: "3em",
+  marginBlockEnd: "1em",
+});
+
+export const ArticleHeading3 = styled("h3")({
+  fontWeight: "normal",
+  fontSize: rem(24),
+  marginBlockStart: "3em",
+  marginBlockEnd: "1em",
+});

--- a/components/text/index.ts
+++ b/components/text/index.ts
@@ -1,0 +1,2 @@
+export * from "./Paragraph";
+export * from "./headings";

--- a/content-processing/indexes/all-content.ts
+++ b/content-processing/indexes/all-content.ts
@@ -1,8 +1,11 @@
 import { taskEither } from "fp-ts";
 import { flow, pipe } from "fp-ts/function";
 import { z } from "zod";
-import { ExtractLeftFromEither, ExtractResultFromTask } from "../../lib/fp-ts";
-import { ParsedArticleWithMetadata } from "../parse-articles";
+import type {
+  ExtractLeftFromEither,
+  ExtractResultFromTask,
+} from "../../lib/fp-ts";
+import type { ParsedArticleWithMetadata } from "../parse-articles";
 import { safeParseSchema } from "../utils";
 import { indexedArticleMetadataSchema } from "./schema";
 import {

--- a/content-processing/indexes/per-topic.ts
+++ b/content-processing/indexes/per-topic.ts
@@ -2,7 +2,10 @@ import { array, either, io, string, task, taskEither } from "fp-ts";
 import { flow, pipe } from "fp-ts/function";
 import path from "path";
 import { z } from "zod";
-import { ExtractLeftFromEither, ExtractResultFromTask } from "../../lib/fp-ts";
+import type {
+  ExtractLeftFromEither,
+  ExtractResultFromTask,
+} from "../../lib/fp-ts";
 import type { ParsedArticleWithMetadata } from "../parse-articles";
 import { safeParseSchema } from "../utils";
 import { indexedArticleMetadataSchema } from "./schema";

--- a/content-processing/indexes/slug-reverse-mapping.ts
+++ b/content-processing/indexes/slug-reverse-mapping.ts
@@ -1,7 +1,7 @@
 import { either, taskEither } from "fp-ts";
 import { flow, pipe } from "fp-ts/function";
 import { z } from "zod";
-import { ParsedArticleWithMetadata } from "../parse-articles";
+import type { ParsedArticleWithMetadata } from "../parse-articles";
 import { safeParseSchema } from "../utils";
 import { indexedArticleMetadataSchema } from "./schema";
 import {

--- a/content-processing/utils.ts
+++ b/content-processing/utils.ts
@@ -1,6 +1,6 @@
 import { either } from "fp-ts";
 import { pipe } from "fp-ts/function";
-import { z, ZodTypeDef } from "zod";
+import type { z, ZodTypeDef } from "zod";
 
 // NOTE: the suggestion from the zod README to use z.ZodType or
 // z.ZodTypeAny leads to this function returning `any`

--- a/content/articles/2022/07/02-fp-ts-sequence-errors/article.mdx
+++ b/content/articles/2022/07/02-fp-ts-sequence-errors/article.mdx
@@ -4,7 +4,7 @@ date: 2022-07-02
 tags: fp-ts, TypeScript
 slug: collecting-multiple-errors-fp-ts
 summary:
-  <a href="https://github.com/gcanti/fp-ts">fp-ts</a> puts errors to the
+  The [fp-ts](https://github.com/gcanti/fp-ts) library puts errors to the
   forefront and helps write type-safe code that correctly reports errors.
   Collecting errors from multiple operations can sometimes lead to boilerplate
   code. Let's see if there is a way to make that code shorter.

--- a/pages/article/[slug].tsx
+++ b/pages/article/[slug].tsx
@@ -2,16 +2,12 @@ import { either, taskEither } from "fp-ts";
 import { serialize } from "next-mdx-remote/serialize";
 import { MDXProvider } from "@mdx-js/react";
 import { pipe } from "fp-ts/function";
-import { GetStaticPaths, GetStaticProps, PageConfig } from "next";
-import Link from "next/link";
-import { ParsedUrlQuery } from "querystring";
+import type { GetStaticPaths, GetStaticProps, PageConfig } from "next";
+import type { ParsedUrlQuery } from "querystring";
 import {
   ArticleHeader,
   StyledArticleContainer,
-  StyledArticleParagraph,
-  StyledArticleParagraphLink,
   StyledArticleSection,
-  StyledArticleSectionHeading,
 } from "../../components/ArticlePage";
 import { Layout } from "../../components/Layout";
 import {
@@ -28,7 +24,7 @@ import {
   ErrorAlert,
   ErrorAlertContainer,
 } from "../../components/ErrorAlert";
-import { IndexedArticleMetadata } from "../../content-processing/indexes/schema";
+import type { IndexedArticleMetadata } from "../../content-processing/indexes/schema";
 import { HeadDocumentTitle, HeadMetaDescription } from "../../seo";
 import stripMarkdown from "strip-markdown";
 import { remark } from "remark";
@@ -36,7 +32,7 @@ import rehypeHighlight from "rehype-highlight";
 import rehypeImageSize from "rehype-img-size";
 import "highlight.js/styles/base16/gruvbox-dark-medium.css";
 import { WithWrappedCodeBlock } from "../../components/WithWrappedCodeBlock";
-import Image from "next/image";
+import { baseMDXComponents } from "../../components/mdx";
 
 interface SourceWithMetadata {
   mdxSource: MDXRemoteSerializeResult;
@@ -90,31 +86,8 @@ const ArticlePage = ({ sourceWithMetadataResult }: ArticlePageProps) => {
                 <StyledArticleSection>
                   <MDXProvider
                     components={{
-                      a: (props) =>
-                        props.href ? (
-                          <Link href={props.href} passHref>
-                            <StyledArticleParagraphLink {...props} />
-                          </Link>
-                        ) : (
-                          (() => {
-                            throw new Error("Link does not have a href");
-                          })()
-                        ),
-                      p: StyledArticleParagraph,
-                      h2: StyledArticleSectionHeading,
+                      ...baseMDXComponents,
                       WithWrappedCodeBlock,
-                      img: (props) => (
-                        <Image
-                          // NOTE: required to fix a TS error
-                          src={props.src as string}
-                          // NOTE: required to tell ESLint we do pass `alt`
-                          alt={props.alt}
-                          {...props}
-                          // NOTE: required to fix a TS error
-                          placeholder={undefined}
-                          layout="responsive"
-                        />
-                      ),
                     }}
                   >
                     <MDXRemote {...mdxSource} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import { either, taskEither } from "fp-ts";
 import { pipe } from "fp-ts/function";
-import { GetStaticProps } from "next";
-import { ComponentProps } from "react";
+import type { GetStaticProps } from "next";
+import type { ComponentProps } from "react";
 import { serializeSummaryInIndexedArticles } from "../components/ArticleCard";
 import { HomePage } from "../components/HomePage";
 import { readAllArticlesIndex } from "../content-processing/indexes";

--- a/pages/topic/[name].tsx
+++ b/pages/topic/[name].tsx
@@ -1,8 +1,8 @@
 import { either, taskEither } from "fp-ts";
 import { pipe } from "fp-ts/function";
-import { GetStaticPaths, GetStaticProps } from "next";
-import { ParsedUrlQuery } from "querystring";
-import { ComponentProps } from "react";
+import type { GetStaticPaths, GetStaticProps } from "next";
+import type { ParsedUrlQuery } from "querystring";
+import type { ComponentProps } from "react";
 import { serializeSummaryInIndexedArticles } from "../../components/ArticleCard";
 import { TopicPage } from "../../components/TopicPage";
 import { reserializeIfError } from "../../content-processing/app-utils";

--- a/pages/topics.tsx
+++ b/pages/topics.tsx
@@ -1,5 +1,5 @@
-import { GetStaticProps } from "next";
-import { ComponentProps } from "react";
+import type { GetStaticProps } from "next";
+import type { ComponentProps } from "react";
 import { TopicsPage } from "../components/TopicsPage";
 import { reserializeIfError } from "../content-processing/app-utils";
 

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -18,7 +18,7 @@ export const blogTheme = {
       border: "rgba(43, 33, 24, 0.3)",
     },
   },
-};
+} as const;
 
 type BlogTheme = typeof blogTheme;
 

--- a/styles/typography.ts
+++ b/styles/typography.ts
@@ -8,7 +8,7 @@ export const articleTitleStyle = css({
 });
 
 export const headingStyle = css({
-  fontSize: rem(20),
+  fontSize: rem(28),
   fontWeight: "normal",
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "importsNotUsedAsValues": "error",
     "forceConsistentCasingInFileNames": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
* Increase most font sizes. The base font size is now 18px for regular text.
* Add explicit styles for h3 headings. Make them related to h2 headings.
* Add more whitespace between list items.
* Add a placeholder for the hero image on about page.
* Make inline `code` stand out more.
* Add more space between the end of the page and the footer.

Moreover, I enabled `importsNotUsedAsValues` in `tsconfig.json`. This prevents type-only imports from being mistaken as regular imports.