### PR TITLE
fix(rss): use correct URLs

### DIFF
--- a/content-processing/create-rss-feed.ts
+++ b/content-processing/create-rss-feed.ts
@@ -24,7 +24,7 @@ const createRSSFeed = pipe(
         date: new Date(article.date),
         // TODO: possibly strip out Markdown
         description: article.summary,
-        url: `${siteURL}articles/${article.slug}`,
+        url: `${siteURL}article/${article.slug}`,
       })
     );
 


### PR DESCRIPTION
Fix the article links in the RSS feed.

Use www.gregroz.me instead of the Vercel deployment URL as the hostname for articles in production. This makes the links more stable.